### PR TITLE
Add an option to limit items in the search dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Canopy React Multi-select Component
 
 ### Props
 + `items`: Items to choose from
++ `maxSearchItems`: Limit the number of items rendered in the dialog
 + `initialSelectedItems`: The selected items
 + `onChange`: Called when selected items change
 + `onInputChange`: Called when the text input changes

--- a/src/multi-selector.js
+++ b/src/multi-selector.js
@@ -245,6 +245,12 @@ const MultiSelector = React.createClass({
 			filterItems.push(this.state.searchValue);
 		}
 
+		if (this.props.maxSearchItems) {
+			filterItems.length = filterItems.length > this.props.maxSearchItems
+				? this.props.maxSearchItems
+				: filterItems.length;
+		}
+
 		return filterItems.map((item, index) => {
 			return (
 				<div

--- a/src/multi-selector.spec.js
+++ b/src/multi-selector.spec.js
@@ -186,4 +186,40 @@ describe('multi-selector', function() {
 		let itemElements = TestUtils.scryRenderedDOMComponentsWithClass(multiSelect, 'heeeelo');
 		expect(itemElements.length).toBe(3);
 	});
+
+	it('Should render max list of items in search dialog', function() {
+		let items = [
+			{
+				"lastName": "Seward",
+				"label": "William Seward",
+				"firstName": "William"
+			},
+			{
+				"lastName": "Montgomery",
+				"label": "Blair Montgomery",
+				"firstName": "Blair"
+			},
+			{
+				"lastName": "Meriwether",
+				"label": "Lewis Meriwether",
+				"firstName": "Lewis"
+			}
+		];
+
+		let MyItemComponent = React.createClass({
+			render: function() {
+				return <div className="heeeelo">{this.props.item.firstName}</div>
+			}
+		});
+
+		let multiSelect = TestUtils.renderIntoDocument(
+			<MultiSelector maxSearchItems={1} items={items} ItemComponent={MyItemComponent}></MultiSelector>
+		);
+
+		let renderedInput = TestUtils.findRenderedDOMComponentWithClass(multiSelect, 'cpr-multi-selector__main-input');
+		TestUtils.Simulate.click(renderedInput);
+
+		let itemElements = TestUtils.scryRenderedDOMComponentsWithClass(multiSelect, 'heeeelo');
+		expect(itemElements.length).toBe(1);
+	});
 });


### PR DESCRIPTION
Workflow is dying in IE when only ~60 items are rendered in the pop-out. This allows us to limit how many items are rendered while still allowing search across all items.