### PR TITLE
Update lastModifiedItem when an item is removed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cpr-multiselect",
-	"version": "3.3.10",
+	"version": "3.3.11",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/multi-selector.js
+++ b/src/multi-selector.js
@@ -149,6 +149,7 @@ export default class MultiSelector extends React.Component {
     this.setState(
       {
         selectedItems: without(this.state.selectedItems, item),
+        lastModifiedItem: item,
       },
       this.triggerItemChange
     );
@@ -427,11 +428,11 @@ export default class MultiSelector extends React.Component {
     let pills = this.state.selectedItems
 			.map((item, i) => {
 				return (
-					<Pill 
-            key={item[this.props.pillUniqueIdentifier] || i} 
-            item={item} 
-            removeItem={partial(this.removeItem, item)} 
-            color={this.props.color} 
+					<Pill
+            key={item[this.props.pillUniqueIdentifier] || i}
+            item={item}
+            removeItem={partial(this.removeItem, item)}
+            color={this.props.color}
             getItemTitle={getItemTitle}
           />
 				);


### PR DESCRIPTION
`lastModifiedItem` was not getting updated when an item was removed from CprMultiSelect.

I know ideally this package ought to be condensed into canopy-styleguide, but as that will take time to migrate from cpr-multiselect over to canopy-styleguide/multiselect, I think updating the main package is necessary, for now. 