### PR TITLE
prevent null selectedItems causing nullRef error

### DIFF
--- a/src/multi-selector.js
+++ b/src/multi-selector.js
@@ -426,18 +426,18 @@ export default class MultiSelector extends React.Component {
     let getItemTitle = this.props.getItemTitle || this.getItemTitle;
     let PillBoxComponent = this.props.CustomPillboxComponent || DefaultPillBoxComponent;
     let Pill = this.props.CustomPill || DefaultPill
-    let pills = this.state.selectedItems
-			.map((item, i) => {
-				return (
-					<Pill
-            key={item[this.props.pillUniqueIdentifier] || i}
-            item={item}
-            removeItem={partial(this.removeItem, item)}
-            color={this.props.color}
-            getItemTitle={getItemTitle}
-          />
-				);
-			});
+    let pills = (this.state.selectedItems || [])
+    .map((item, i) => {
+      return (
+        <Pill
+          key={item[this.props.pillUniqueIdentifier] || i}
+          item={item}
+          removeItem={partial(this.removeItem, item)}
+          color={this.props.color}
+          getItemTitle={getItemTitle}
+        />
+      );
+    });
 
     let dialog;
 


### PR DESCRIPTION
When you remove the last selected item, the lodash `without` method is used, and sets the array to null instead of an empty array.  This has the effect of causing a nullRef error when the pills section is mapped over that array.

This PR sets an empty array to map over if selectedItems is null or undefined.

also reverted the tabs back to spaces from a previous PR to be consistent with the rest of the file